### PR TITLE
Make DTOs Codable

### DIFF
--- a/Sources/AppleMapsKit/DTOs/AutocompleteResult.swift
+++ b/Sources/AppleMapsKit/DTOs/AutocompleteResult.swift
@@ -1,5 +1,5 @@
 /// An object that contains information you can use to suggest addresses and further refine search results.
-public struct AutocompleteResult: Decodable, Sendable {
+public struct AutocompleteResult: Codable, Sendable {
     /// The relative URI to the `search` endpoint to use to fetch more details pertaining to the result.
     ///
     /// If available, the framework encodes opaque data about the autocomplete result in the completion URL’s `metadata` parameter.
@@ -19,7 +19,7 @@ public struct AutocompleteResult: Decodable, Sendable {
 }
 
 /// An array of autocomplete results.
-struct SearchAutocompleteResponse: Decodable, Sendable {
+struct SearchAutocompleteResponse: Codable, Sendable {
     /// An array of ``AutocompleteResult`` objects.
     public let results: [AutocompleteResult]?
 }

--- a/Sources/AppleMapsKit/DTOs/DirectionsResponse.swift
+++ b/Sources/AppleMapsKit/DTOs/DirectionsResponse.swift
@@ -1,5 +1,5 @@
 /// An object that describes the directions from a starting location to a destination in terms routes, steps, and a series of waypoints.
-public struct DirectionsResponse: Decodable, Sendable {
+public struct DirectionsResponse: Codable, Sendable {
     /// A ``Place`` object that describes the destination.
     public let destination: Place?
 
@@ -24,7 +24,7 @@ public struct DirectionsResponse: Decodable, Sendable {
     public let steps: [Step]?
 }
 
-public enum DirectionsTransportType: String, Decodable, Sendable {
+public enum DirectionsTransportType: String, Codable, Sendable {
     case automobile = "Automobile"
     case walking = "Walking"
 }
@@ -37,7 +37,7 @@ public enum DirectionsAvoid: String, Sendable {
 
 extension DirectionsResponse {
     /// An object that represent the components of a single route.
-    public struct Route: Decodable, Sendable {
+    public struct Route: Codable, Sendable {
         /// Total distance that the route covers, in meters.
         public let distanceMeters: Int?
 
@@ -71,7 +71,7 @@ extension DirectionsResponse {
     }
 
     /// An object that represents a step along a route.
-    public struct Step: Decodable, Sendable {
+    public struct Step: Codable, Sendable {
         /// Total distance covered by the step, in meters.
         public let distanceMeters: Int?
 

--- a/Sources/AppleMapsKit/DTOs/ErrorResponse.swift
+++ b/Sources/AppleMapsKit/DTOs/ErrorResponse.swift
@@ -1,5 +1,5 @@
 /// Information about an error that occurs while processing a request.
-public struct ErrorResponse: Error, Decodable, Sendable {
+public struct ErrorResponse: Error, Codable, Sendable {
     /// An array of strings with additional details about the error.
     public let details: [String]?
 

--- a/Sources/AppleMapsKit/DTOs/Eta.swift
+++ b/Sources/AppleMapsKit/DTOs/Eta.swift
@@ -1,5 +1,5 @@
 /// An object that contains details about an estimated time of arrival (ETA).
-public struct Eta: Decodable, Sendable {
+public struct Eta: Codable, Sendable {
     /// The destination as a ``Location``.
     public let destination: Location?
 
@@ -17,12 +17,12 @@ public struct Eta: Decodable, Sendable {
 }
 
 /// An object that contains an array of one or more estimated times of arrival (ETAs).
-struct EtaResponse: Decodable, Sendable {
+struct EtaResponse: Codable, Sendable {
     /// An array of one or more ``EtaResponse/Eta`` objects.
     public let etas: [Eta]?
 }
 
-public enum EtaTransportType: String, Decodable, Sendable {
+public enum EtaTransportType: String, Codable, Sendable {
     case automobile = "Automobile"
     case walking = "Walking"
     case transit = "Transit"

--- a/Sources/AppleMapsKit/DTOs/MapRegion.swift
+++ b/Sources/AppleMapsKit/DTOs/MapRegion.swift
@@ -1,5 +1,5 @@
 /// An object that describes an area to search in terms of its upper-right and lower-left corners as a pair of geographic points.
-public struct MapRegion: Decodable, Sendable {
+public struct MapRegion: Codable, Sendable {
     /// A double value that describes the east longitude of the map region.
     public let eastLongitude: Double?
 

--- a/Sources/AppleMapsKit/DTOs/Place.swift
+++ b/Sources/AppleMapsKit/DTOs/Place.swift
@@ -1,5 +1,5 @@
 /// An object that describes a place in terms of a variety of spatial, administrative, and qualitative properties.
-public struct Place: Decodable, Sendable {
+public struct Place: Codable, Sendable {
     /// The country or region of the place.
     public let country: String?
 
@@ -35,7 +35,7 @@ public struct Place: Decodable, Sendable {
 }
 
 /// An object that describes a location in terms of its longitude and latitude.
-public struct Location: Decodable, Sendable {
+public struct Location: Codable, Sendable {
     /// A double value that describes the latitude of the coordinate.
     public let latitude: Double?
 
@@ -44,7 +44,7 @@ public struct Location: Decodable, Sendable {
 }
 
 /// An object that describes the detailed address components of a place.
-public struct StructuredAddress: Decodable, Sendable {
+public struct StructuredAddress: Codable, Sendable {
     /// The state or province of the place.
     public let administrativeArea: String?
 
@@ -77,7 +77,7 @@ public struct StructuredAddress: Decodable, Sendable {
 }
 
 /// An object that contains an array of places.
-struct PlaceResults: Decodable {
+struct PlaceResults: Codable {
     /// An array of one or more ``Place`` objects.
     let results: [Place]?
 }

--- a/Sources/AppleMapsKit/DTOs/PoiCategory.swift
+++ b/Sources/AppleMapsKit/DTOs/PoiCategory.swift
@@ -1,5 +1,5 @@
 /// A string that describes a specific point of interest (POI) category.
-public enum PoiCategory: String, Decodable, Sendable {
+public enum PoiCategory: String, Codable, Sendable {
     /// An airport.
     case airport = "Airport"
 

--- a/Sources/AppleMapsKit/DTOs/SearchResponse.swift
+++ b/Sources/AppleMapsKit/DTOs/SearchResponse.swift
@@ -1,5 +1,5 @@
 /// An object that contains the search region and an array of place descriptions that a search returns.
-public struct SearchResponse: Decodable, Sendable {
+public struct SearchResponse: Codable, Sendable {
     /// Represents a rectangular region on a map expressed as south-west and north-east points.
     ///
     /// More specifically south latitude, west longitude, north latitude and east longitude.
@@ -13,7 +13,7 @@ public struct SearchResponse: Decodable, Sendable {
 
 extension SearchResponse {
     /// An object that returns a page of search responses.
-    public struct PaginationInfo: Decodable, Sendable {
+    public struct PaginationInfo: Codable, Sendable {
         /// An opaque string that the server uses to fetch the next page of search responses.
         public let nextPageToken: String?
 

--- a/Sources/AppleMapsKit/DTOs/TokenResponse.swift
+++ b/Sources/AppleMapsKit/DTOs/TokenResponse.swift
@@ -1,5 +1,5 @@
 /// An object that contains an access token and an expiration time in seconds.
-struct TokenResponse: Decodable {
+struct TokenResponse: Codable {
     /// A string that represents the access token.
     let accessToken: String
 


### PR DESCRIPTION
Making DTOs `Codable` give the availability  to encode or decode them in other frameworks, for example if you want to return the response directly as JSON in HB, you have to confirm to Encodable which is not an easy thing in Swift 6 since you need to do the encoding manually due to:

`Extension outside of file declaring struct 'Place' prevents automatic synthesis of 'encode(to:)' for protocol 'Encodable'`