### PR TITLE
Authorization Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Returns the latitude and longitude of the address you specify.
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -53,7 +53,7 @@ Returns an array of addresses present at the coordinates you provide.
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -75,7 +75,7 @@ Find places by name or by specific search criteria.
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -97,7 +97,7 @@ Find results that you can use to autocomplete searches.
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -119,7 +119,7 @@ Find directions by specific criteria.
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -144,7 +144,7 @@ Returns the estimated time of arrival (ETA) and distance between starting and en
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",
@@ -177,7 +177,7 @@ Obtain a set of ``Place`` objects for a given set of Place IDs or get a list of 
 import AppleMapsKit
 import AsyncHTTPClient
 
-let client = try await AppleMapsClient(
+let client = AppleMapsClient(
     httpClient: HTTPClient(...),
     teamID: "DEF123GHIJ",
     keyID: "ABC123DEFG",

--- a/Sources/AppleMapsKit/Authorization/AuthorizationProvider.swift
+++ b/Sources/AppleMapsKit/Authorization/AuthorizationProvider.swift
@@ -1,0 +1,133 @@
+//
+//  AuthorizationProvider.swift
+//  apple-maps-kit
+//
+//  Created by FarouK on 11/10/2024.
+//
+
+import AsyncHTTPClient
+import Foundation
+import JWTKit
+import NIOHTTP1
+
+// MARK: - auth/c & auth/z
+internal actor AuthorizationProvider {
+
+    private let httpClient: HTTPClient
+    private let apiServer: String
+    private let teamID: String
+    private let keyID: String
+    private let key: String
+
+    private var currentToken: TokenResponse?
+    private var refreshTask: Task<TokenResponse, any Error>?
+
+    internal init(httpClient: HTTPClient, apiServer: String, teamID: String, keyID: String, key: String) {
+        self.httpClient = httpClient
+        self.apiServer = apiServer
+        self.teamID = teamID
+        self.keyID = keyID
+        self.key = key
+    }
+
+    func validToken() async throws -> TokenResponse {
+        // If we're currently refreshing a token, await the value for our refresh task to make sure we return the refreshed token.
+        if let handle = refreshTask {
+            return try await handle.value
+        }
+
+        // If we don't have a current token, we request a new one.
+        guard let token = currentToken else {
+            return try await refreshToken()
+        }
+
+        if token.isValid {
+            return token
+        }
+
+        // None of the above applies so we'll need to refresh the token.
+        return try await refreshToken()
+    }
+
+    private func refreshToken() async throws -> TokenResponse {
+        if let refreshTask = refreshTask {
+            return try await refreshTask.value
+        }
+
+        let task = Task { () throws -> TokenResponse in
+            defer { refreshTask = nil }
+            let authToken = try await createJWT(teamID: teamID, keyID: keyID, key: key)
+            let newToken = try await getAccessToken(authToken: authToken)
+            currentToken = newToken
+            return newToken
+        }
+
+        self.refreshTask = task
+        return try await task.value
+    }
+}
+
+// MARK: - HELPERS
+extension AuthorizationProvider {
+
+    /// Makes an HTTP request to exchange Auth token for Access token.
+    ///
+    /// - Parameters:
+    ///   - httpClient: The HTTP client to use.
+    ///   - authToken: The authorization token.
+    ///
+    /// - Throws: Error response object.
+    ///
+    /// - Returns: An access token.
+    fileprivate func getAccessToken(authToken: String) async throws -> TokenResponse {
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(authToken)")
+
+        var request = HTTPClientRequest(url: "\(apiServer)/v1/token")
+        request.headers = headers
+
+        let response = try await httpClient.execute(request, timeout: .seconds(30))
+
+        if response.status == .ok {
+            return try await JSONDecoder()
+                .decode(TokenResponse.self, from: response.body.collect(upTo: 1024 * 1024))
+        } else {
+            throw try await JSONDecoder().decode(ErrorResponse.self, from: response.body.collect(upTo: 1024 * 1024))
+        }
+    }
+
+    /// Creates a JWT token, which is auth token in this context.
+    ///
+    /// - Parameters:
+    ///   - teamID: A 10-character Team ID obtained from your Apple Developer account.
+    ///   - keyID: A 10-character key identifier that provides the ID of the private key that you obtain from your Apple Developer account.
+    ///   - key: A MapKit JS private key.
+    ///
+    /// - Returns: A JWT token represented as `String`.
+    fileprivate func createJWT(teamID: String, keyID: String, key: String) async throws -> String {
+        let keys = try await JWTKeyCollection().add(ecdsa: ES256PrivateKey(pem: key))
+
+        var header = JWTHeader()
+        header.alg = "ES256"
+        header.kid = keyID
+        header.typ = "JWT"
+
+        struct Payload: JWTPayload {
+            let iss: IssuerClaim
+            let iat: IssuedAtClaim
+            let exp: ExpirationClaim
+
+            func verify(using key: some JWTAlgorithm) throws {
+                try self.exp.verifyNotExpired()
+            }
+        }
+
+        let payload = Payload(
+            iss: IssuerClaim(value: teamID),
+            iat: IssuedAtClaim(value: Date()),
+            exp: ExpirationClaim(value: Date().addingTimeInterval(30 * 60))
+        )
+
+        return try await keys.sign(payload, header: header)
+    }
+}

--- a/Sources/AppleMapsKit/Authorization/TokenResponse.swift
+++ b/Sources/AppleMapsKit/Authorization/TokenResponse.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// An object that contains an access token and an expiration time in seconds.
+internal struct TokenResponse: Codable {
+    /// A string that represents the access token.
+    let accessToken: String
+
+    /// An integer that indicates the time, in seconds from now until the token expires.
+    let expiresInSeconds: Int
+
+    /// A date that indicates when then token will expire.
+    let expirationDate: Date
+
+    internal init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.accessToken = try container.decode(String.self, forKey: .accessToken)
+        self.expiresInSeconds = try container.decode(Int.self, forKey: .expiresInSeconds)
+        self.expirationDate = Date.now.addingTimeInterval(TimeInterval(expiresInSeconds))
+    }
+
+    internal init(accessToken: String, expiresInSeconds: Int) {
+        self.accessToken = accessToken
+        self.expiresInSeconds = expiresInSeconds
+        self.expirationDate = Date.now.addingTimeInterval(TimeInterval(expiresInSeconds))
+    }
+
+}
+
+extension TokenResponse {
+
+    /// A boolean indicates whether to token is valid 10 seconds before it's actual expiry time.
+    var isValid: Bool {
+        let currentDate = Date.now
+        // we consider a token invalid 10 seconds before it actual expiry time, so we have some time to refresh it.
+        let expirationBuffer: TimeInterval = 10
+        return currentDate < (expirationDate - expirationBuffer)
+    }
+}

--- a/Sources/AppleMapsKit/DTOs/TokenResponse.swift
+++ b/Sources/AppleMapsKit/DTOs/TokenResponse.swift
@@ -1,8 +1,0 @@
-/// An object that contains an access token and an expiration time in seconds.
-struct TokenResponse: Codable {
-    /// A string that represents the access token.
-    let accessToken: String
-
-    /// An integer that indicates the time, in seconds from now until the token expires.
-    let expiresInSeconds: Int
-}

--- a/Tests/AppleMapsKitTests/AppleMapsKitTests.swift
+++ b/Tests/AppleMapsKitTests/AppleMapsKitTests.swift
@@ -8,7 +8,7 @@ struct AppleMapsKitTests {
 
     init() async throws {
         // TODO: Replace the following values with valid ones.
-        client = try await AppleMapsClient(
+        client = AppleMapsClient(
             httpClient: HTTPClient.shared,
             teamID: "DEF123GHIJ",
             keyID: "ABC123DEFG",

--- a/Tests/AppleMapsKitTests/AuthorizationProviderTests.swift
+++ b/Tests/AppleMapsKitTests/AuthorizationProviderTests.swift
@@ -1,0 +1,28 @@
+//
+//  AuthorizationProviderTests.swift
+//  apple-maps-kit
+//
+//  Created by FarouK on 12/10/2024.
+//
+
+import Testing
+
+@testable import AppleMapsKit
+
+struct AuthorizationProviderTests {
+
+    struct TokenValidityTests {
+        // It's 1 second actually due to the expiration buffer on the token.
+        let token = TokenResponse(accessToken: "some token", expiresInSeconds: 11)
+
+        @Test func tokenInvalidCheck() async {
+            try? await Task.sleep(for: .seconds(2))
+            #expect(token.isValid == false)
+        }
+
+        @Test func tokenValidCheck() async {
+            #expect(token.isValid)
+        }
+    }
+
+}


### PR DESCRIPTION
Currently if the token is expired, every request after it fails and there is no way of refreshing it since it's being done on the client init.
this PR introduces better authorization handling, with the following changes:

- token is no longer being fetched on init, because you usually create the client on the server start, you want that to be as fast as possible (you don't want to make the server start waits for a network call to finish).
- token is fetched when needed if it's not there.
- token is refreshed automatically if it's expired 10 seconds before it's actual expiry, so the client requests don't get un-authorized).
- only one token refresh happens at the same time, if multiple requests are trying to access the token while it's being refreshed, all of them wait for that single refresh and take it's result.

The refresh flow is inspired by this article:
[Building a token refresh flow with async/await and Swift Concurrency
](https://www.donnywals.com/building-a-token-refresh-flow-with-async-await-and-swift-concurrency/)