### PR TITLE
Revert back to using the default SPI build version for documentation builds

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,3 @@ version: 1
 builder:
   configs:
     - documentation_targets: [AppleMapsKit]
-      swift_version: 6.0


### PR DESCRIPTION
We recently switched SPI to use 6.0 by default. There would be no harm in leaving this as explicitly set to 6.0 for now, but while I remember it’s still here I thought I’d revert it so that when we get to 6.5, this explicitly set version hasn’t rolled off the bottom of what we support.