### PR TITLE
build: add NIOCore and NIOFoundationCompat as an explicit dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.1.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.96.0"),
     ],
     targets: [
         .target(
@@ -22,6 +23,9 @@ let package = Package(
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "JWTKit", package: "jwt-kit"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings
         ),


### PR DESCRIPTION
I faced this issue when building a Docker image using Swift 6.2:
```
773.7 [923/926] Compiling AppleMapsKit AppleMapsClient.swift
773.7 /build/.build/checkouts/apple-maps-kit/Sources/AppleMapsKit/AppleMapsClient.swift:4:8: error: no such module 'NIOFoundationCompat'
773.7   2 | import Foundation
773.7   3 | import NIO
773.7   4 | import NIOFoundationCompat
773.7     |        `- error: no such module 'NIOFoundationCompat'
773.7   5 | import NIOHTTP1
773.7   6 |
```
I found this related issue on the forums due to Linux, however the solution was to explicitly add `NIOCore` and `NIOFoundationCompat` as dependencies.
https://forums.swift.org/t/compile-error-without-importing-niofoundationcompat-on-linux-but-not-macos/72761